### PR TITLE
StringTokenisizer

### DIFF
--- a/SyntaxRefer/StringTokensizer.java
+++ b/SyntaxRefer/StringTokensizer.java
@@ -1,0 +1,18 @@
+static class FastScanner {
+		BufferedReader br=new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st=new StringTokenizer("");
+		String next() {
+			while (!st.hasMoreTokens())
+				try { 
+                                        st=new StringTokenizer(br.readLine());				               
+                                } catch (IOException e) {}
+			return st.nextToken();
+		}
+
+		int nextInt() {
+			return Integer.parseInt(next());
+		}
+		long nextLong() {
+			return Long.parseLong(next());
+		}
+	}


### PR DESCRIPTION
Java for competitive coding have faced a “TLE” even though their logic and complexity are well within the bounds. Therefore compress your entire input section to this and then just used FastScanner instead of Scanner.